### PR TITLE
fixes #2 support product name on device list

### DIFF
--- a/.changeset/great-queens-bake.md
+++ b/.changeset/great-queens-bake.md
@@ -1,0 +1,5 @@
+---
+"@ecoflow-api/schemas": patch
+---
+
+- fixes #2 - support "productName" field on device-list

--- a/packages/schemas/src/shared/deviceListResponseSchema.ts
+++ b/packages/schemas/src/shared/deviceListResponseSchema.ts
@@ -14,6 +14,7 @@ export const deviceListResponseSchema = z.object({
       sn: z.string(),
       online: z.literal(0).or(z.literal(1)),
       deviceName: z.string().optional(),
+      productName: z.string(),
     }),
   ),
 });


### PR DESCRIPTION
The field "productName" is now returned by the API if device-list is requested.
The field has been added to the schemas to support the field in the rest-client.