### PR TITLE
Fix # 26 optional product name

### DIFF
--- a/.changeset/curly-forks-rush.md
+++ b/.changeset/curly-forks-rush.md
@@ -1,0 +1,7 @@
+---
+"@ecoflow-api/rest-client": patch
+"@ecoflow-api/schemas": patch
+"examples": patch
+---
+
+fix #26: productName in device-list response to be optional

--- a/packages/schemas/src/shared/deviceListResponseSchema.ts
+++ b/packages/schemas/src/shared/deviceListResponseSchema.ts
@@ -16,7 +16,7 @@ export const deviceListResponseSchema = z.object({
         sn: z.string(),
         online: zeroOrOne,
         deviceName: z.string().optional(),
-        productName: z.string(),
+        productName: z.string().optional(),
       })
       .passthrough(),
   ),


### PR DESCRIPTION
productName in devicelist response to be optional to avoid getDevicesPlain() to fail